### PR TITLE
customize ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
+  # Skip DWARF for CI: linking alloy + solana-sdk dominates this job.
+  CARGO_PROFILE_DEV_DEBUG: "0"
+  CARGO_PROFILE_TEST_DEBUG: "0"
 
 jobs:
   rust:
@@ -24,6 +27,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Install mold
+        uses: rui314/setup-mold@v1
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
@@ -31,8 +37,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: ". -> target"
-          # PRs restore from main; skip the cache-upload wait on every PR.
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          shared-key: ci-linux
 
       # Skip taurvia-desktop: compiling Tauri needs WebKit GTK and only runs a
       # Specta bindings export. Bindings are committed; tsc covers the TS side.

--- a/crates/taurvia-bitcoin/src/rpc.rs
+++ b/crates/taurvia-bitcoin/src/rpc.rs
@@ -117,7 +117,7 @@ impl BtcRpc {
         let me = signer.address.to_lowercase();
         Ok(txs
             .into_iter()
-            .take(limit.max(1).min(25))
+            .take(limit.clamp(1, 25))
             .map(|tx| {
                 let incoming: u64 = tx
                     .vout
@@ -265,7 +265,7 @@ impl BtcRpc {
         let send_sats = (amount_btc * SATS_PER_BTC).round() as u64;
         let mut utxos = self.utxos(&signer.address).await?;
         utxos.retain(|u| u.status.confirmed);
-        utxos.sort_by(|a, b| b.value.cmp(&a.value));
+        utxos.sort_by_key(|u| std::cmp::Reverse(u.value));
         let fee_rate = self.fee_rate_sat_vb().await?;
 
         let mut selected = Vec::new();

--- a/crates/taurvia-evm/src/activity.rs
+++ b/crates/taurvia-evm/src/activity.rs
@@ -34,7 +34,7 @@ pub async fn activity(
     let url = format!(
         "{api}?module=account&action=txlist&address={}&page=1&offset={}&sort=desc",
         signer.address,
-        limit.max(1).min(25)
+        limit.clamp(1, 25)
     );
     let resp: EtherscanResponse = taurvia_chain::http_client()
         .get(url)


### PR DESCRIPTION
No debuginfo (CARGO_PROFILE_*_DEBUG=0) so linking is much lighter
mold as the linker
One shared Rust cache (shared-key: ci-linux) saved on PRs as well as main, so the next push is a cache hit instead of a cold rebuild